### PR TITLE
switch to interface for greater flexibility

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Logger returns a request logging middleware
-func Logger(category string, logger *logrus.Logger) func(h http.Handler) http.Handler {
+func Logger(category string, logger logrus.FieldLogger) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			reqID := middleware.GetReqID(r.Context())

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -49,6 +49,25 @@ func TestLogger(t *testing.T) {
 	assert.Equal(t, "http://localhost:8080/", hook.LastEntry().Message)
 }
 
+func TestEntry(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Host = "localhost:8080"
+
+	logger, hook := test.NewNullLogger()
+	entry := logger.WithField("entry", "exists")
+
+	testRequest(t, req, Logger("router", entry))
+
+	assert.Equal(t, 1, len(hook.Entries))
+	assert.Equal(t, logrus.InfoLevel, hook.LastEntry().Level)
+	assert.Equal(t, "exists", hook.LastEntry().Data["entry"])
+	assert.Nil(t, hook.LastEntry().Data["request_id"])
+	assert.Equal(t, "GET", hook.LastEntry().Data["method"])
+	assert.Equal(t, 11, hook.LastEntry().Data["bytes"])
+	assert.Greater(t, hook.LastEntry().Data["duration"], int64(0))
+	assert.Equal(t, "http://localhost:8080/", hook.LastEntry().Message)
+}
+
 func TestLoggerRequestID(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Host = "localhost:8080"


### PR DESCRIPTION
By using `logrus.FieldLogger` we get greater flexibility, like the ability to add global fields.

Tests included.