### PR TITLE
Adding configuration to include the request headers in the log

### DIFF
--- a/logger_config.go
+++ b/logger_config.go
@@ -1,0 +1,37 @@
+package logger
+
+import "github.com/sirupsen/logrus"
+
+type LoggerConfig struct {
+	level                 logrus.Level
+	includeRequestHeaders bool
+}
+
+type LoggerConfigBuilder struct {
+	loggerConfig *LoggerConfig
+}
+
+func NewLoggerConfigBuilder() *LoggerConfigBuilder {
+	loggerConfig := &LoggerConfig{
+		level:                 logrus.InfoLevel,
+		includeRequestHeaders: false,
+	}
+
+	return &LoggerConfigBuilder{
+		loggerConfig: loggerConfig,
+	}
+}
+
+func (lcb *LoggerConfigBuilder) WithLoggingLevel(level logrus.Level) *LoggerConfigBuilder {
+	lcb.loggerConfig.level = level
+	return lcb
+}
+
+func (lcb *LoggerConfigBuilder) WithRequestHeadersIncluded() *LoggerConfigBuilder {
+	lcb.loggerConfig.includeRequestHeaders = true
+	return lcb
+}
+
+func (lcb *LoggerConfigBuilder) Build() LoggerConfig {
+	return *lcb.loggerConfig
+}

--- a/logger_config_test.go
+++ b/logger_config_test.go
@@ -1,0 +1,46 @@
+package logger
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	config := NewLoggerConfigBuilder().Build()
+
+	assert.NotNil(t, config)
+	assert.False(t, config.includeRequestHeaders)
+	assert.Equal(t, logrus.InfoLevel, config.level)
+}
+
+func TestConfigWithDebugLevel(t *testing.T) {
+	config := NewLoggerConfigBuilder().
+		WithLoggingLevel(logrus.DebugLevel).
+		Build()
+
+	assert.NotNil(t, config)
+	assert.False(t, config.includeRequestHeaders)
+	assert.Equal(t, logrus.DebugLevel, config.level)
+}
+
+func TestConfigWithIncludedHeaders(t *testing.T) {
+	config := NewLoggerConfigBuilder().
+		WithRequestHeadersIncluded().
+		Build()
+
+	assert.NotNil(t, config)
+	assert.True(t, config.includeRequestHeaders)
+	assert.Equal(t, logrus.InfoLevel, config.level)
+}
+
+func TestConfigWithDebugLevelAndIncludedHeaders(t *testing.T) {
+	config := NewLoggerConfigBuilder().
+		WithLoggingLevel(logrus.DebugLevel).
+		WithRequestHeadersIncluded().
+		Build()
+
+	assert.NotNil(t, config)
+	assert.True(t, config.includeRequestHeaders)
+	assert.Equal(t, logrus.DebugLevel, config.level)
+}


### PR DESCRIPTION
Making the configuration flexible so not to require further changes of the methods.

Add configuration to include the request headers in the log.